### PR TITLE
add cusolver functions and helpers

### DIFF
--- a/src/lapack/backends/cusolver/cusolver_helper.hpp
+++ b/src/lapack/backends/cusolver/cusolver_helper.hpp
@@ -173,6 +173,14 @@ public:
         throw cusolver_error(std::string(#name) + std::string(" : "), err); \
     }
 
+inline cusolverEigMode_t get_cusolver_job(oneapi::mkl::job jobz) {
+    switch (jobz) {
+        case oneapi::mkl::job::N: return CUSOLVER_EIG_MODE_NOVECTOR;
+        case oneapi::mkl::job::V: return CUSOLVER_EIG_MODE_VECTOR;
+        default: throw "Wrong jobz.";
+    }
+}
+
 inline signed char get_cusolver_jobsvd(oneapi::mkl::jobsvd job) {
     switch (job) {
         case oneapi::mkl::jobsvd::N: return 'N';
@@ -204,6 +212,14 @@ inline cublasSideMode_t get_cublas_side_mode(oneapi::mkl::side lr) {
         case oneapi::mkl::side::left: return CUBLAS_SIDE_LEFT;
         case oneapi::mkl::side::right: return CUBLAS_SIDE_RIGHT;
         default: throw "Wrong side mode.";
+    }
+}
+
+inline cublasSideMode_t get_cublas_generate(oneapi::mkl::generate qp) {
+    switch (qp) {
+        case oneapi::mkl::generate::Q: return CUBLAS_SIDE_LEFT;
+        case oneapi::mkl::generate::P: return CUBLAS_SIDE_RIGHT;
+        default: throw "Wrong generate.";
     }
 }
 

--- a/src/lapack/backends/cusolver/cusolver_lapack.cpp
+++ b/src/lapack/backends/cusolver/cusolver_lapack.cpp
@@ -354,48 +354,150 @@ void hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
            std::int64_t scratchpad_size) {
     throw unimplemented("lapack", "hetrf");
 }
-void orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
-           std::int64_t k, sycl::buffer<float> &a, std::int64_t lda, sycl::buffer<float> &tau,
-           sycl::buffer<float> &scratchpad, std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "orgbr");
+
+template <typename Func, typename T>
+inline void orgbr(Func func, sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
+                  std::int64_t n, std::int64_t k, sycl::buffer<T> &a, std::int64_t lda,
+                  sycl::buffer<T> &tau, sycl::buffer<T> &scratchpad, std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(m, n, k, lda, scratchpad_size);
+    queue.submit([&](cl::sycl::handler &cgh) {
+        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto tau_acc = tau.template get_access<cl::sycl::access::mode::read>(cgh);
+        auto scratch_acc = scratchpad.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType *>(a_acc);
+            auto tau_ = sc.get_mem<cuDataType *>(tau_acc);
+            auto scratch_ = sc.get_mem<cuDataType *>(scratch_acc);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_generate(vec), m, n, k, a_, lda, tau_,
+                                scratch_, scratchpad_size, nullptr);
+        });
+    });
 }
-void orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
-           std::int64_t k, sycl::buffer<double> &a, std::int64_t lda, sycl::buffer<double> &tau,
-           sycl::buffer<double> &scratchpad, std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "orgbr");
+
+#define ORGBR_LAUNCHER(TYPE, CUSOLVER_ROUTINE)                                                   \
+    void orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,    \
+               std::int64_t k, sycl::buffer<TYPE> &a, std::int64_t lda, sycl::buffer<TYPE> &tau, \
+               sycl::buffer<TYPE> &scratchpad, std::int64_t scratchpad_size) {                   \
+        orgbr(CUSOLVER_ROUTINE, queue, vec, m, n, k, a, lda, tau, scratchpad, scratchpad_size);  \
+    }
+
+ORGBR_LAUNCHER(float, cusolverDnSorgbr)
+ORGBR_LAUNCHER(double, cusolverDnDorgbr)
+
+#undef ORGBR_LAUNCHER
+
+template <typename Func, typename T>
+inline void orgqr(Func func, sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
+                  sycl::buffer<T> &a, std::int64_t lda, sycl::buffer<T> &tau,
+                  sycl::buffer<T> &scratchpad, std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(m, n, k, lda, scratchpad_size);
+    queue.submit([&](cl::sycl::handler &cgh) {
+        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto tau_acc = tau.template get_access<cl::sycl::access::mode::read>(cgh);
+        auto scratch_acc = scratchpad.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType *>(a_acc);
+            auto tau_ = sc.get_mem<cuDataType *>(tau_acc);
+            auto scratch_ = sc.get_mem<cuDataType *>(scratch_acc);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, m, n, k, a_, lda, tau_, scratch_,
+                                scratchpad_size, nullptr);
+        });
+    });
 }
-void orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
-           sycl::buffer<double> &a, std::int64_t lda, sycl::buffer<double> &tau,
-           sycl::buffer<double> &scratchpad, std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "orgqr");
+
+#define ORGQR_LAUNCHER(TYPE, CUSOLVER_ROUTINE)                                             \
+    void orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,         \
+               sycl::buffer<TYPE> &a, std::int64_t lda, sycl::buffer<TYPE> &tau,           \
+               sycl::buffer<TYPE> &scratchpad, std::int64_t scratchpad_size) {             \
+        orgqr(CUSOLVER_ROUTINE, queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size); \
+    }
+
+ORGQR_LAUNCHER(float, cusolverDnSorgqr)
+ORGQR_LAUNCHER(double, cusolverDnDorgqr)
+
+#undef ORGQR_LAUNCHER
+
+template <typename Func, typename T>
+inline void orgtr(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
+                  sycl::buffer<T> &a, std::int64_t lda, sycl::buffer<T> &tau,
+                  sycl::buffer<T> &scratchpad, std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(n, lda, scratchpad_size);
+    queue.submit([&](cl::sycl::handler &cgh) {
+        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto tau_acc = tau.template get_access<cl::sycl::access::mode::read>(cgh);
+        auto scratch_acc = scratchpad.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType *>(a_acc);
+            auto tau_ = sc.get_mem<cuDataType *>(tau_acc);
+            auto scratch_ = sc.get_mem<cuDataType *>(scratch_acc);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_fill_mode(uplo), n, a_, lda, tau_,
+                                scratch_, scratchpad_size, nullptr);
+        });
+    });
 }
-void orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
-           sycl::buffer<float> &a, std::int64_t lda, sycl::buffer<float> &tau,
-           sycl::buffer<float> &scratchpad, std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "orgqr");
+
+#define ORGTR_LAUNCHER(TYPE, CUSOLVER_ROUTINE)                                                    \
+    void orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, sycl::buffer<TYPE> &a, \
+               std::int64_t lda, sycl::buffer<TYPE> &tau, sycl::buffer<TYPE> &scratchpad,         \
+               std::int64_t scratchpad_size) {                                                    \
+        orgtr(CUSOLVER_ROUTINE, queue, uplo, n, a, lda, tau, scratchpad, scratchpad_size);        \
+    }
+
+ORGTR_LAUNCHER(float, cusolverDnSorgtr)
+ORGTR_LAUNCHER(double, cusolverDnDorgtr)
+
+#undef ORGTR_LAUNCHER
+
+template <typename Func, typename T>
+inline void ormtr(Func func, sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
+                  oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, sycl::buffer<T> &a,
+                  std::int64_t lda, sycl::buffer<T> &tau, sycl::buffer<T> &c, std::int64_t ldc,
+                  sycl::buffer<T> &scratchpad, std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(m, n, lda, ldc, scratchpad_size);
+    queue.submit([&](cl::sycl::handler &cgh) {
+        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto tau_acc = tau.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto c_acc = c.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto scratch_acc = scratchpad.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType *>(a_acc);
+            auto tau_ = sc.get_mem<cuDataType *>(tau_acc);
+            auto c_ = sc.get_mem<cuDataType *>(c_acc);
+            auto scratch_ = sc.get_mem<cuDataType *>(scratch_acc);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_side_mode(side),
+                                get_cublas_fill_mode(uplo), get_cublas_operation(trans), m, n, a_,
+                                lda, tau_, c_, ldc, scratch_, scratchpad_size, nullptr);
+        });
+    });
 }
-void orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, sycl::buffer<float> &a,
-           std::int64_t lda, sycl::buffer<float> &tau, sycl::buffer<float> &scratchpad,
-           std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "orgtr");
-}
-void orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, sycl::buffer<double> &a,
-           std::int64_t lda, sycl::buffer<double> &tau, sycl::buffer<double> &scratchpad,
-           std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "orgtr");
-}
-void ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
-           oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, sycl::buffer<float> &a,
-           std::int64_t lda, sycl::buffer<float> &tau, sycl::buffer<float> &c, std::int64_t ldc,
-           sycl::buffer<float> &scratchpad, std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "ormtr");
-}
-void ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
-           oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, sycl::buffer<double> &a,
-           std::int64_t lda, sycl::buffer<double> &tau, sycl::buffer<double> &c, std::int64_t ldc,
-           sycl::buffer<double> &scratchpad, std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "ormtr");
-}
+
+#define ORMTR_LAUNCHER(TYPE, CUSOLVER_ROUTINE)                                                   \
+    void ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,               \
+               oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,                     \
+               sycl::buffer<TYPE> &a, std::int64_t lda, sycl::buffer<TYPE> &tau,                 \
+               sycl::buffer<TYPE> &c, std::int64_t ldc, sycl::buffer<TYPE> &scratchpad,          \
+               std::int64_t scratchpad_size) {                                                   \
+        ormtr(CUSOLVER_ROUTINE, queue, side, uplo, trans, m, n, a, lda, tau, c, ldc, scratchpad, \
+              scratchpad_size);                                                                  \
+    }
+
+ORMTR_LAUNCHER(float, cusolverDnSormtr)
+ORMTR_LAUNCHER(double, cusolverDnDormtr)
+
+#undef ORMTR_LAUNCHER
+
 void ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans, std::int64_t m,
            std::int64_t n, std::int64_t k, sycl::buffer<float> &a, std::int64_t lda,
            sycl::buffer<float> &tau, sycl::buffer<float> &c, std::int64_t ldc,
@@ -408,18 +510,46 @@ void ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose tr
            sycl::buffer<double> &scratchpad, std::int64_t scratchpad_size) {
     throw unimplemented("lapack", "ormrq");
 }
-void ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans, std::int64_t m,
-           std::int64_t n, std::int64_t k, sycl::buffer<double> &a, std::int64_t lda,
-           sycl::buffer<double> &tau, sycl::buffer<double> &c, std::int64_t ldc,
-           sycl::buffer<double> &scratchpad, std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "ormqr");
+
+template <typename Func, typename T>
+inline void ormqr(Func func, sycl::queue &queue, oneapi::mkl::side side,
+                  oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k,
+                  sycl::buffer<T> &a, std::int64_t lda, sycl::buffer<T> &tau, sycl::buffer<T> &c,
+                  std::int64_t ldc, sycl::buffer<T> &scratchpad, std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(m, n, k, lda, ldc, scratchpad_size);
+    queue.submit([&](cl::sycl::handler &cgh) {
+        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
+        auto tau_acc = tau.template get_access<cl::sycl::access::mode::read>(cgh);
+        auto c_acc = c.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto scratch_acc = scratchpad.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType *>(a_acc);
+            auto tau_ = sc.get_mem<cuDataType *>(tau_acc);
+            auto c_ = sc.get_mem<cuDataType *>(c_acc);
+            auto scratch_ = sc.get_mem<cuDataType *>(scratch_acc);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_side_mode(side),
+                                get_cublas_operation(trans), m, n, k, a_, lda, tau_, c_, ldc,
+                                scratch_, scratchpad_size, nullptr);
+        });
+    });
 }
-void ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans, std::int64_t m,
-           std::int64_t n, std::int64_t k, sycl::buffer<float> &a, std::int64_t lda,
-           sycl::buffer<float> &tau, sycl::buffer<float> &c, std::int64_t ldc,
-           sycl::buffer<float> &scratchpad, std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "ormqr");
-}
+
+#define ORMQR_LAUNCHER(TYPE, CUSOLVER_ROUTINE)                                                     \
+    void ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,           \
+               std::int64_t m, std::int64_t n, std::int64_t k, sycl::buffer<TYPE> &a,              \
+               std::int64_t lda, sycl::buffer<TYPE> &tau, sycl::buffer<TYPE> &c, std::int64_t ldc, \
+               sycl::buffer<TYPE> &scratchpad, std::int64_t scratchpad_size) {                     \
+        ormqr(CUSOLVER_ROUTINE, queue, side, trans, m, n, k, a, lda, tau, c, ldc, scratchpad,      \
+              scratchpad_size);                                                                    \
+    }
+
+ORMQR_LAUNCHER(float, cusolverDnSormqr)
+ORMQR_LAUNCHER(double, cusolverDnDormqr)
+
+#undef ORMQR_LAUNCHER
 
 template <typename Func, typename T>
 inline void potrf(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
@@ -494,16 +624,45 @@ void potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int6
            sycl::buffer<std::complex<double>> &scratchpad, std::int64_t scratchpad_size) {
     throw unimplemented("lapack", "potrs");
 }
-void syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
-           sycl::buffer<double> &a, std::int64_t lda, sycl::buffer<double> &w,
-           sycl::buffer<double> &scratchpad, std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "syevd");
+
+template <typename Func, typename T>
+inline void syevd(Func func, sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
+                  std::int64_t n, sycl::buffer<T> &a, std::int64_t lda, sycl::buffer<T> &w,
+                  sycl::buffer<T> &scratchpad, std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(n, lda, scratchpad_size);
+    sycl::buffer<int> devInfo{ 1 };
+    queue.submit([&](cl::sycl::handler &cgh) {
+        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto w_acc = w.template get_access<cl::sycl::access::mode::write>(cgh);
+        auto devInfo_acc = devInfo.template get_access<cl::sycl::access::mode::write>(cgh);
+        auto scratch_acc = scratchpad.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType *>(a_acc);
+            auto w_ = sc.get_mem<cuDataType *>(w_acc);
+            auto devInfo_ = sc.get_mem<int *>(devInfo_acc);
+            auto scratch_ = sc.get_mem<cuDataType *>(scratch_acc);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cusolver_job(jobz),
+                                get_cublas_fill_mode(uplo), n, a_, lda, w_, scratch_,
+                                scratchpad_size, devInfo_);
+        });
+    });
 }
-void syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
-           sycl::buffer<float> &a, std::int64_t lda, sycl::buffer<float> &w,
-           sycl::buffer<float> &scratchpad, std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "syevd");
-}
+
+#define SYEVD_LAUNCHER(TYPE, CUSOLVER_ROUTINE)                                                    \
+    void syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n, \
+               sycl::buffer<TYPE> &a, std::int64_t lda, sycl::buffer<TYPE> &w,                    \
+               sycl::buffer<TYPE> &scratchpad, std::int64_t scratchpad_size) {                    \
+        syevd(CUSOLVER_ROUTINE, queue, jobz, uplo, n, a, lda, w, scratchpad, scratchpad_size);    \
+    }
+
+SYEVD_LAUNCHER(float, cusolverDnSsyevd)
+SYEVD_LAUNCHER(double, cusolverDnDsyevd)
+
+#undef SYEVD_LAUNCHER
+
 void sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
            std::int64_t n, sycl::buffer<double> &a, std::int64_t lda, sycl::buffer<double> &b,
            std::int64_t ldb, sycl::buffer<double> &w, sycl::buffer<double> &scratchpad,
@@ -516,39 +675,100 @@ void sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz, oneapi
            std::int64_t scratchpad_size) {
     throw unimplemented("lapack", "sygvd");
 }
-void sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, sycl::buffer<double> &a,
-           std::int64_t lda, sycl::buffer<double> &d, sycl::buffer<double> &e,
-           sycl::buffer<double> &tau, sycl::buffer<double> &scratchpad,
-           std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "sytrd");
+
+template <typename Func, typename T>
+inline void sytrd(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
+                  sycl::buffer<T> &a, std::int64_t lda, sycl::buffer<T> &d, sycl::buffer<T> &e,
+                  sycl::buffer<T> &tau, sycl::buffer<T> &scratchpad, std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(n, lda, scratchpad_size);
+    queue.submit([&](cl::sycl::handler &cgh) {
+        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto d_acc = d.template get_access<cl::sycl::access::mode::write>(cgh);
+        auto e_acc = e.template get_access<cl::sycl::access::mode::write>(cgh);
+        auto tau_acc = tau.template get_access<cl::sycl::access::mode::write>(cgh);
+        auto scratch_acc = scratchpad.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType *>(a_acc);
+            auto d_ = sc.get_mem<cuDataType *>(d_acc);
+            auto e_ = sc.get_mem<cuDataType *>(e_acc);
+            auto tau_ = sc.get_mem<cuDataType *>(tau_acc);
+            auto scratch_ = sc.get_mem<cuDataType *>(scratch_acc);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_fill_mode(uplo), n, a_, lda, d_, e_,
+                                tau_, scratch_, scratchpad_size, nullptr);
+        });
+    });
 }
-void sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, sycl::buffer<float> &a,
-           std::int64_t lda, sycl::buffer<float> &d, sycl::buffer<float> &e,
-           sycl::buffer<float> &tau, sycl::buffer<float> &scratchpad,
-           std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "sytrd");
+
+#define SYTRD_LAUNCHER(TYPE, CUSOLVER_ROUTINE)                                                    \
+    void sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, sycl::buffer<TYPE> &a, \
+               std::int64_t lda, sycl::buffer<TYPE> &d, sycl::buffer<TYPE> &e,                    \
+               sycl::buffer<TYPE> &tau, sycl::buffer<TYPE> &scratchpad,                           \
+               std::int64_t scratchpad_size) {                                                    \
+        sytrd(CUSOLVER_ROUTINE, queue, uplo, n, a, lda, d, e, tau, scratchpad, scratchpad_size);  \
+    }
+
+SYTRD_LAUNCHER(float, cusolverDnSsytrd)
+SYTRD_LAUNCHER(double, cusolverDnDsytrd)
+
+#undef SYTRD_LAUNCHER
+
+template <typename Func, typename T>
+inline void sytrf(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
+                  sycl::buffer<T> &a, std::int64_t lda, sycl::buffer<std::int64_t> &ipiv,
+                  sycl::buffer<T> &scratchpad, std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(n, lda, scratchpad_size);
+    sycl::buffer<int> devInfo{ 1 };
+
+    // cusolver legacy api does not accept 64-bit ints
+    // Create new buffer with 32-bit ints then copy over
+    std::uint64_t ipiv_size = n;
+    sycl::buffer<int, 1> ipiv32(sycl::range<1>{ ipiv_size });
+
+    queue.submit([&](cl::sycl::handler &cgh) {
+        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto ipiv32_acc = ipiv32.template get_access<cl::sycl::access::mode::write>(cgh);
+        auto devInfo_acc = devInfo.template get_access<cl::sycl::access::mode::write>(cgh);
+        auto scratch_acc = scratchpad.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType *>(a_acc);
+            auto ipiv32_ = sc.get_mem<int *>(ipiv32_acc);
+            auto devInfo_ = sc.get_mem<int *>(devInfo_acc);
+            auto scratch_ = sc.get_mem<cuDataType *>(scratch_acc);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_fill_mode(uplo), n, a_, lda, ipiv32_,
+                                scratch_, scratchpad_size, devInfo_);
+        });
+    });
+
+    // Copy from 32-bit buffer to 64-bit
+    queue.submit([&](cl::sycl::handler &cgh) {
+        auto ipiv32_acc = ipiv32.template get_access<cl::sycl::access::mode::read>(cgh);
+        auto ipiv_acc = ipiv.template get_access<cl::sycl::access::mode::write>(cgh);
+        cgh.parallel_for(cl::sycl::range<1>{ ipiv_size }, [=](cl::sycl::id<1> index) {
+            ipiv_acc[index] = static_cast<std::int64_t>(ipiv32_acc[index]);
+        });
+    });
 }
-void sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, sycl::buffer<float> &a,
-           std::int64_t lda, sycl::buffer<std::int64_t> &ipiv, sycl::buffer<float> &scratchpad,
-           std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "sytrf");
-}
-void sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, sycl::buffer<double> &a,
-           std::int64_t lda, sycl::buffer<std::int64_t> &ipiv, sycl::buffer<double> &scratchpad,
-           std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "sytrf");
-}
-void sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
-           sycl::buffer<std::complex<float>> &a, std::int64_t lda, sycl::buffer<std::int64_t> &ipiv,
-           sycl::buffer<std::complex<float>> &scratchpad, std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "sytrf");
-}
-void sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
-           sycl::buffer<std::complex<double>> &a, std::int64_t lda,
-           sycl::buffer<std::int64_t> &ipiv, sycl::buffer<std::complex<double>> &scratchpad,
-           std::int64_t scratchpad_size) {
-    throw unimplemented("lapack", "sytrf");
-}
+
+#define SYTRF_LAUNCHER(TYPE, CUSOLVER_ROUTINE)                                                     \
+    void sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, sycl::buffer<TYPE> &a,  \
+               std::int64_t lda, sycl::buffer<std::int64_t> &ipiv, sycl::buffer<TYPE> &scratchpad, \
+               std::int64_t scratchpad_size) {                                                     \
+        sytrf(CUSOLVER_ROUTINE, queue, uplo, n, a, lda, ipiv, scratchpad, scratchpad_size);        \
+    }
+
+SYTRF_LAUNCHER(float, cusolverDnSsytrf)
+SYTRF_LAUNCHER(double, cusolverDnDsytrf)
+SYTRF_LAUNCHER(std::complex<float>, cusolverDnCsytrf)
+SYTRF_LAUNCHER(std::complex<double>, cusolverDnZsytrf)
+
+#undef SYTRF_LAUNCHER
+
 void trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
            oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs,
            sycl::buffer<std::complex<float>> &a, std::int64_t lda,
@@ -998,48 +1218,165 @@ sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   const std::vector<sycl::event> &dependencies) {
     throw unimplemented("lapack", "hetrf");
 }
-sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
-                  std::int64_t k, float *a, std::int64_t lda, float *tau, float *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "orgbr");
+
+template <typename Func, typename T>
+inline sycl::event orgbr(Func func, sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
+                         std::int64_t n, std::int64_t k, T *a, std::int64_t lda, T *tau,
+                         T *scratchpad, std::int64_t scratchpad_size,
+                         const std::vector<sycl::event> &dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(m, n, k, lda, scratchpad_size);
+    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        int64_t num_events = dependencies.size();
+        for (int64_t i = 0; i < num_events; i++) {
+            cgh.depends_on(dependencies[i]);
+        }
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType *>(a);
+            auto tau_ = reinterpret_cast<cuDataType *>(tau);
+            auto scratch_ = reinterpret_cast<cuDataType *>(scratchpad);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_generate(vec), m, n, k, a_, lda, tau_,
+                                scratch_, scratchpad_size, nullptr);
+        });
+    });
+    return done;
 }
-sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
-                  std::int64_t k, double *a, std::int64_t lda, double *tau, double *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "orgbr");
+
+#define ORGBR_LAUNCHER_USM(TYPE, CUSOLVER_ROUTINE)                                          \
+    sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,        \
+                      std::int64_t n, std::int64_t k, TYPE *a, std::int64_t lda, TYPE *tau, \
+                      TYPE *scratchpad, std::int64_t scratchpad_size,                       \
+                      const std::vector<sycl::event> &dependencies) {                       \
+        return orgbr(CUSOLVER_ROUTINE, queue, vec, m, n, k, a, lda, tau, scratchpad,        \
+                     scratchpad_size, dependencies);                                        \
+    }
+
+ORGBR_LAUNCHER_USM(float, cusolverDnSorgbr)
+ORGBR_LAUNCHER_USM(double, cusolverDnDorgbr)
+
+#undef ORGBR_LAUNCHER_USM
+
+template <typename Func, typename T>
+inline sycl::event orgqr(Func func, sycl::queue &queue, std::int64_t m, std::int64_t n,
+                         std::int64_t k, T *a, std::int64_t lda, T *tau, T *scratchpad,
+                         std::int64_t scratchpad_size,
+                         const std::vector<sycl::event> &dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(m, n, k, lda, scratchpad_size);
+    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        int64_t num_events = dependencies.size();
+        for (int64_t i = 0; i < num_events; i++) {
+            cgh.depends_on(dependencies[i]);
+        }
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType *>(a);
+            auto tau_ = reinterpret_cast<cuDataType *>(tau);
+            auto scratch_ = reinterpret_cast<cuDataType *>(scratchpad);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, m, n, k, a_, lda, tau_, scratch_,
+                                scratchpad_size, nullptr);
+        });
+    });
+    return done;
 }
-sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k, double *a,
-                  std::int64_t lda, double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "orgqr");
+
+#define ORGQR_LAUNCHER_USM(TYPE, CUSOLVER_ROUTINE)                                                 \
+    sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k, TYPE *a, \
+                      std::int64_t lda, TYPE *tau, TYPE *scratchpad, std::int64_t scratchpad_size, \
+                      const std::vector<sycl::event> &dependencies) {                              \
+        return orgqr(CUSOLVER_ROUTINE, queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size,   \
+                     dependencies);                                                                \
+    }
+
+ORGQR_LAUNCHER_USM(float, cusolverDnSorgqr)
+ORGQR_LAUNCHER_USM(double, cusolverDnDorgqr)
+
+#undef ORGQR_LAUNCHER_USM
+
+template <typename Func, typename T>
+inline sycl::event orgtr(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
+                         T *a, std::int64_t lda, T *tau, T *scratchpad,
+                         std::int64_t scratchpad_size,
+                         const std::vector<sycl::event> &dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(n, lda, scratchpad_size);
+    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        int64_t num_events = dependencies.size();
+        for (int64_t i = 0; i < num_events; i++) {
+            cgh.depends_on(dependencies[i]);
+        }
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType *>(a);
+            auto tau_ = reinterpret_cast<cuDataType *>(tau);
+            auto scratch_ = reinterpret_cast<cuDataType *>(scratchpad);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_fill_mode(uplo), n, a_, lda, tau_,
+                                scratch_, scratchpad_size, nullptr);
+        });
+    });
+    return done;
 }
-sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k, float *a,
-                  std::int64_t lda, float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "orgqr");
+
+#define ORGTR_LAUNCHER_USM(TYPE, CUSOLVER_ROUTINE)                                                 \
+    sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, TYPE *a,         \
+                      std::int64_t lda, TYPE *tau, TYPE *scratchpad, std::int64_t scratchpad_size, \
+                      const std::vector<sycl::event> &dependencies) {                              \
+        return orgtr(CUSOLVER_ROUTINE, queue, uplo, n, a, lda, tau, scratchpad, scratchpad_size,   \
+                     dependencies);                                                                \
+    }
+
+ORGTR_LAUNCHER_USM(float, cusolverDnSorgtr)
+ORGTR_LAUNCHER_USM(double, cusolverDnDorgtr)
+
+#undef ORGTR_LAUNCHER_USM
+
+template <typename Func, typename T>
+inline sycl::event ormtr(Func func, sycl::queue &queue, oneapi::mkl::side side,
+                         oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans, std::int64_t m,
+                         std::int64_t n, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc,
+                         T *scratchpad, std::int64_t scratchpad_size,
+                         const std::vector<sycl::event> &dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(m, n, lda, ldc, scratchpad_size);
+    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        int64_t num_events = dependencies.size();
+        for (int64_t i = 0; i < num_events; i++) {
+            cgh.depends_on(dependencies[i]);
+        }
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType *>(a);
+            auto tau_ = reinterpret_cast<cuDataType *>(tau);
+            auto c_ = reinterpret_cast<cuDataType *>(c);
+            auto scratch_ = reinterpret_cast<cuDataType *>(scratchpad);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_side_mode(side),
+                                get_cublas_fill_mode(uplo), get_cublas_operation(trans), m, n, a_,
+                                lda, tau_, c_, ldc, scratch_, scratchpad_size, nullptr);
+        });
+    });
+    return done;
 }
-sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
-                  std::int64_t lda, float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "orgtr");
-}
-sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
-                  std::int64_t lda, double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "orgtr");
-}
-sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
-                  oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, float *a,
-                  std::int64_t lda, float *tau, float *c, std::int64_t ldc, float *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "ormtr");
-}
-sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
-                  oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, double *a,
-                  std::int64_t lda, double *tau, double *c, std::int64_t ldc, double *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "ormtr");
-}
+
+#define ORMTR_LAUNCHER_USM(TYPE, CUSOLVER_ROUTINE)                                              \
+    sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,       \
+                      oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, TYPE *a,    \
+                      std::int64_t lda, TYPE *tau, TYPE *c, std::int64_t ldc, TYPE *scratchpad, \
+                      std::int64_t scratchpad_size,                                             \
+                      const std::vector<sycl::event> &dependencies) {                           \
+        return ormtr(CUSOLVER_ROUTINE, queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,     \
+                     scratchpad, scratchpad_size, dependencies);                                \
+    }
+
+ORMTR_LAUNCHER_USM(float, cusolverDnSormtr)
+ORMTR_LAUNCHER_USM(double, cusolverDnDormtr)
+
+#undef ORMTR_LAUNCHER_USM
+
 sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                   float *tau, float *c, std::int64_t ldc, float *scratchpad,
@@ -1052,18 +1389,49 @@ sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::trans
                   std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("lapack", "ormrq");
 }
-sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
-                  std::int64_t m, std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
-                  double *tau, double *c, std::int64_t ldc, double *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "ormqr");
+
+template <typename Func, typename T>
+inline sycl::event ormqr(Func func, sycl::queue &queue, oneapi::mkl::side side,
+                         oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                         std::int64_t k, T *a, std::int64_t lda, T *tau, T *c, std::int64_t ldc,
+                         T *scratchpad, std::int64_t scratchpad_size,
+                         const std::vector<sycl::event> &dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(m, n, k, lda, ldc, scratchpad_size);
+    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        int64_t num_events = dependencies.size();
+        for (int64_t i = 0; i < num_events; i++) {
+            cgh.depends_on(dependencies[i]);
+        }
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType *>(a);
+            auto tau_ = reinterpret_cast<cuDataType *>(tau);
+            auto c_ = reinterpret_cast<cuDataType *>(c);
+            auto scratch_ = reinterpret_cast<cuDataType *>(scratchpad);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_side_mode(side),
+                                get_cublas_operation(trans), m, n, k, a_, lda, tau_, c_, ldc,
+                                scratch_, scratchpad_size, nullptr);
+        });
+    });
+    return done;
 }
-sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
-                  std::int64_t m, std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
-                  float *tau, float *c, std::int64_t ldc, float *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "ormqr");
-}
+
+#define ORMQR_LAUNCHER_USM(TYPE, CUSOLVER_ROUTINE)                                               \
+    sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,  \
+                      std::int64_t m, std::int64_t n, std::int64_t k, TYPE *a, std::int64_t lda, \
+                      TYPE *tau, TYPE *c, std::int64_t ldc, TYPE *scratchpad,                    \
+                      std::int64_t scratchpad_size,                                              \
+                      const std::vector<sycl::event> &dependencies) {                            \
+        return ormqr(CUSOLVER_ROUTINE, queue, side, trans, m, n, k, a, lda, tau, c, ldc,         \
+                     scratchpad, scratchpad_size, dependencies);                                 \
+    }
+
+ORMQR_LAUNCHER_USM(float, cusolverDnSormqr)
+ORMQR_LAUNCHER_USM(double, cusolverDnDormqr)
+
+#undef ORMQR_LAUNCHER_USM
 
 template <typename Func, typename T>
 inline sycl::event potrf(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
@@ -1145,16 +1513,50 @@ sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, st
                   const std::vector<sycl::event> &dependencies) {
     throw unimplemented("lapack", "potrs");
 }
-sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
-                  double *a, std::int64_t lda, double *w, double *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "syevd");
+
+template <typename Func, typename T>
+inline sycl::event syevd(Func func, sycl::queue &queue, oneapi::mkl::job jobz,
+                         oneapi::mkl::uplo uplo, std::int64_t n, T *a, std::int64_t lda, T *w,
+                         T *scratchpad, std::int64_t scratchpad_size,
+                         const std::vector<sycl::event> &dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(n, lda, scratchpad_size);
+    int *devInfo = (int *)malloc_device(sizeof(int), queue);
+    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        int64_t num_events = dependencies.size();
+        for (int64_t i = 0; i < num_events; i++) {
+            cgh.depends_on(dependencies[i]);
+        }
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType *>(a);
+            auto w_ = reinterpret_cast<cuDataType *>(w);
+            auto scratch_ = reinterpret_cast<cuDataType *>(scratchpad);
+            auto devInfo_ = reinterpret_cast<int *>(devInfo);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cusolver_job(jobz),
+                                get_cublas_fill_mode(uplo), n, a_, lda, w_, scratch_,
+                                scratchpad_size, devInfo_);
+        });
+    });
+
+    return done;
 }
-sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
-                  float *a, std::int64_t lda, float *w, float *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "syevd");
-}
+
+#define SYEVD_LAUNCHER_USM(TYPE, CUSOLVER_ROUTINE)                                          \
+    sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,    \
+                      std::int64_t n, TYPE *a, std::int64_t lda, TYPE *w, TYPE *scratchpad, \
+                      std::int64_t scratchpad_size,                                         \
+                      const std::vector<sycl::event> &dependencies) {                       \
+        return syevd(CUSOLVER_ROUTINE, queue, jobz, uplo, n, a, lda, w, scratchpad,         \
+                     scratchpad_size, dependencies);                                        \
+    }
+
+SYEVD_LAUNCHER_USM(float, cusolverDnSsyevd)
+SYEVD_LAUNCHER_USM(double, cusolverDnDsyevd)
+
+#undef SYEVD_LAUNCHER_USM
+
 sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda, double *b,
                   std::int64_t ldb, double *w, double *scratchpad, std::int64_t scratchpad_size,
@@ -1167,38 +1569,106 @@ sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   const std::vector<sycl::event> &dependencies) {
     throw unimplemented("lapack", "sygvd");
 }
-sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
-                  std::int64_t lda, double *d, double *e, double *tau, double *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "sytrd");
+
+template <typename Func, typename T>
+inline sycl::event sytrd(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
+                         T *a, std::int64_t lda, T *d, T *e, T *tau, T *scratchpad,
+                         std::int64_t scratchpad_size,
+                         const std::vector<sycl::event> &dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(n, lda, scratchpad_size);
+    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        int64_t num_events = dependencies.size();
+        for (int64_t i = 0; i < num_events; i++) {
+            cgh.depends_on(dependencies[i]);
+        }
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType *>(a);
+            auto d_ = reinterpret_cast<cuDataType *>(d);
+            auto e_ = reinterpret_cast<cuDataType *>(e);
+            auto tau_ = reinterpret_cast<cuDataType *>(tau);
+            auto scratch_ = reinterpret_cast<cuDataType *>(scratchpad);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_fill_mode(uplo), n, a_, lda, d_, e_,
+                                tau_, scratch_, scratchpad_size, nullptr);
+        });
+    });
+    return done;
 }
-sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
-                  std::int64_t lda, float *d, float *e, float *tau, float *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "sytrd");
+
+#define SYTRD_LAUNCHER_USM(TYPE, CUSOLVER_ROUTINE)                                         \
+    sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, TYPE *a, \
+                      std::int64_t lda, TYPE *d, TYPE *e, TYPE *tau, TYPE *scratchpad,     \
+                      std::int64_t scratchpad_size,                                        \
+                      const std::vector<sycl::event> &dependencies) {                      \
+        return sytrd(CUSOLVER_ROUTINE, queue, uplo, n, a, lda, d, e, tau, scratchpad,      \
+                     scratchpad_size, dependencies);                                       \
+    }
+
+SYTRD_LAUNCHER_USM(float, cusolverDnSsytrd)
+SYTRD_LAUNCHER_USM(double, cusolverDnDsytrd)
+
+#undef SYTRD_LAUNCHER_USM
+
+template <typename Func, typename T>
+inline sycl::event sytrf(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
+                         T *a, std::int64_t lda, std::int64_t *ipiv, T *scratchpad,
+                         std::int64_t scratchpad_size,
+                         const std::vector<sycl::event> &dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(n, lda, scratchpad_size);
+    int *devInfo = (int *)malloc_device(sizeof(int), queue);
+
+    // cusolver legacy api does not accept 64-bit ints
+    // Create USM with 32-bit ints then copy over
+    std::uint64_t ipiv_size = n;
+    int *ipiv32 = (int *)malloc_device(ipiv_size, queue);
+
+    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        int64_t num_events = dependencies.size();
+        for (int64_t i = 0; i < num_events; i++) {
+            cgh.depends_on(dependencies[i]);
+        }
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType *>(a);
+            auto scratch_ = reinterpret_cast<cuDataType *>(scratchpad);
+            auto ipiv_ = reinterpret_cast<int *>(ipiv32);
+            auto devInfo_ = reinterpret_cast<int *>(devInfo);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_fill_mode(uplo), n, a_, lda, ipiv_,
+                                scratch_, scratchpad_size, devInfo_);
+        });
+    });
+
+    // Copy from 32-bit USM to 64-bit
+    queue.submit([&](cl::sycl::handler &cgh) {
+        cgh.parallel_for(cl::sycl::range<1>{ ipiv_size },
+                         [=](cl::sycl::id<1> index) { ipiv[index] = ipiv32[index]; });
+    });
+
+    free(ipiv32, queue);
+
+    return done;
 }
-sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
-                  std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "sytrf");
-}
-sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
-                  std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
-                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "sytrf");
-}
-sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
-                  std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
-                  std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "sytrf");
-}
-sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
-                  std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
-                  std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("lapack", "sytrf");
-}
+
+#define SYTRF_LAUNCHER_USM(TYPE, CUSOLVER_ROUTINE)                                                \
+    sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, TYPE *a,        \
+                      std::int64_t lda, std::int64_t *ipiv, TYPE *scratchpad,                     \
+                      std::int64_t scratchpad_size,                                               \
+                      const std::vector<sycl::event> &dependencies) {                             \
+        return sytrf(CUSOLVER_ROUTINE, queue, uplo, n, a, lda, ipiv, scratchpad, scratchpad_size, \
+                     dependencies);                                                               \
+    }
+
+SYTRF_LAUNCHER_USM(float, cusolverDnSsytrf)
+SYTRF_LAUNCHER_USM(double, cusolverDnDsytrf)
+SYTRF_LAUNCHER_USM(std::complex<float>, cusolverDnCsytrf)
+SYTRF_LAUNCHER_USM(std::complex<double>, cusolverDnZsytrf)
+
+#undef SYTRF_LAUNCHER_USM
+
 sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
@@ -1534,38 +2004,89 @@ std::int64_t hetrf_scratchpad_size<std::complex<double>>(sycl::queue &queue, one
                                                          std::int64_t n, std::int64_t lda) {
     throw unimplemented("lapack", "hetrf_scratchpad_size");
 }
-template <>
-std::int64_t orgbr_scratchpad_size<float>(sycl::queue &queue, oneapi::mkl::generate vect,
-                                          std::int64_t m, std::int64_t n, std::int64_t k,
-                                          std::int64_t lda) {
-    throw unimplemented("lapack", "orgbr_scratchpad_size");
+
+template <typename Func>
+inline void orgbr_scratchpad_size(Func func, sycl::queue &queue, oneapi::mkl::generate vec,
+                                  std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda,
+                                  int *scratch_size) {
+    queue.submit([&](cl::sycl::handler &cgh) {
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_generate(vec), m, n, k, nullptr, lda,
+                                nullptr, scratch_size);
+        });
+    });
 }
-template <>
-std::int64_t orgbr_scratchpad_size<double>(sycl::queue &queue, oneapi::mkl::generate vect,
-                                           std::int64_t m, std::int64_t n, std::int64_t k,
-                                           std::int64_t lda) {
-    throw unimplemented("lapack", "orgbr_scratchpad_size");
+
+#define ORGBR_LAUNCHER_SCRATCH(TYPE, CUSOLVER_ROUTINE)                                       \
+    template <>                                                                              \
+    std::int64_t orgbr_scratchpad_size<TYPE>(sycl::queue & queue, oneapi::mkl::generate vec, \
+                                             std::int64_t m, std::int64_t n, std::int64_t k, \
+                                             std::int64_t lda) {                             \
+        int scratch_size;                                                                    \
+        orgbr_scratchpad_size(CUSOLVER_ROUTINE, queue, vec, m, n, k, lda, &scratch_size);    \
+        return scratch_size;                                                                 \
+    }
+
+ORGBR_LAUNCHER_SCRATCH(float, cusolverDnSorgbr_bufferSize)
+ORGBR_LAUNCHER_SCRATCH(double, cusolverDnDorgbr_bufferSize)
+
+#undef ORGBR_LAUNCHER_SCRATCH
+
+template <typename Func>
+inline void orgtr_scratchpad_size(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                  std::int64_t n, std::int64_t lda, int *scratch_size) {
+    queue.submit([&](cl::sycl::handler &cgh) {
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_fill_mode(uplo), n, nullptr, lda,
+                                nullptr, scratch_size);
+        });
+    });
 }
-template <>
-std::int64_t orgtr_scratchpad_size<float>(sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                          std::int64_t n, std::int64_t lda) {
-    throw unimplemented("lapack", "orgtr_scratchpad_size");
+
+#define ORGTR_LAUNCHER_SCRATCH(TYPE, CUSOLVER_ROUTINE)                                    \
+    template <>                                                                           \
+    std::int64_t orgtr_scratchpad_size<TYPE>(sycl::queue & queue, oneapi::mkl::uplo uplo, \
+                                             std::int64_t n, std::int64_t lda) {          \
+        int scratch_size;                                                                 \
+        orgtr_scratchpad_size(CUSOLVER_ROUTINE, queue, uplo, n, lda, &scratch_size);      \
+        return scratch_size;                                                              \
+    }
+
+ORGTR_LAUNCHER_SCRATCH(float, cusolverDnSorgtr_bufferSize)
+ORGTR_LAUNCHER_SCRATCH(double, cusolverDnDorgtr_bufferSize)
+
+#undef ORGTR_LAUNCHER_SCRATCH
+
+template <typename Func>
+inline void orgqr_scratchpad_size(Func func, sycl::queue &queue, std::int64_t m, std::int64_t n,
+                                  std::int64_t k, std::int64_t lda, int *scratch_size) {
+    queue.submit([&](cl::sycl::handler &cgh) {
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, m, n, k, nullptr, lda, nullptr, scratch_size);
+        });
+    });
 }
-template <>
-std::int64_t orgtr_scratchpad_size<double>(sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                           std::int64_t n, std::int64_t lda) {
-    throw unimplemented("lapack", "orgtr_scratchpad_size");
-}
-template <>
-std::int64_t orgqr_scratchpad_size<float>(sycl::queue &queue, std::int64_t m, std::int64_t n,
-                                          std::int64_t k, std::int64_t lda) {
-    throw unimplemented("lapack", "orgqr_scratchpad_size");
-}
-template <>
-std::int64_t orgqr_scratchpad_size<double>(sycl::queue &queue, std::int64_t m, std::int64_t n,
-                                           std::int64_t k, std::int64_t lda) {
-    throw unimplemented("lapack", "orgqr_scratchpad_size");
-}
+
+#define ORGQR_LAUNCHER_SCRATCH(TYPE, CUSOLVER_ROUTINE)                                            \
+    template <>                                                                                   \
+    std::int64_t orgqr_scratchpad_size<TYPE>(sycl::queue & queue, std::int64_t m, std::int64_t n, \
+                                             std::int64_t k, std::int64_t lda) {                  \
+        int scratch_size;                                                                         \
+        orgqr_scratchpad_size(CUSOLVER_ROUTINE, queue, m, n, k, lda, &scratch_size);              \
+        return scratch_size;                                                                      \
+    }
+
+ORGQR_LAUNCHER_SCRATCH(float, cusolverDnSorgqr_bufferSize)
+ORGQR_LAUNCHER_SCRATCH(double, cusolverDnDorgqr_bufferSize)
+
+#undef ORGQR_LAUNCHER_SCRATCH
+
 template <>
 std::int64_t ormrq_scratchpad_size<float>(sycl::queue &queue, oneapi::mkl::side side,
                                           oneapi::mkl::transpose trans, std::int64_t m,
@@ -1580,34 +2101,71 @@ std::int64_t ormrq_scratchpad_size<double>(sycl::queue &queue, oneapi::mkl::side
                                            std::int64_t ldc) {
     throw unimplemented("lapack", "ormrq_scratchpad_size");
 }
-template <>
-std::int64_t ormqr_scratchpad_size<float>(sycl::queue &queue, oneapi::mkl::side side,
-                                          oneapi::mkl::transpose trans, std::int64_t m,
-                                          std::int64_t n, std::int64_t k, std::int64_t lda,
-                                          std::int64_t ldc) {
-    throw unimplemented("lapack", "ormqr_scratchpad_size");
+
+template <typename Func>
+inline void ormqr_scratchpad_size(Func func, sycl::queue &queue, oneapi::mkl::side side,
+                                  oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                                  std::int64_t k, std::int64_t lda, std::int64_t ldc,
+                                  int *scratch_size) {
+    queue.submit([&](cl::sycl::handler &cgh) {
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_side_mode(side),
+                                get_cublas_operation(trans), m, n, k, nullptr, lda, nullptr,
+                                nullptr, ldc, scratch_size);
+        });
+    });
 }
-template <>
-std::int64_t ormqr_scratchpad_size<double>(sycl::queue &queue, oneapi::mkl::side side,
-                                           oneapi::mkl::transpose trans, std::int64_t m,
-                                           std::int64_t n, std::int64_t k, std::int64_t lda,
-                                           std::int64_t ldc) {
-    throw unimplemented("lapack", "ormqr_scratchpad_size");
+
+#define ORMQRF_LAUNCHER_SCRATCH(TYPE, CUSOLVER_ROUTINE)                                            \
+    template <>                                                                                    \
+    std::int64_t ormqr_scratchpad_size<TYPE>(                                                      \
+        sycl::queue & queue, oneapi::mkl::side side, oneapi::mkl::transpose trans, std::int64_t m, \
+        std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t ldc) {                      \
+        int scratch_size;                                                                          \
+        ormqr_scratchpad_size(CUSOLVER_ROUTINE, queue, side, trans, m, n, k, lda, ldc,             \
+                              &scratch_size);                                                      \
+        return scratch_size;                                                                       \
+    }
+
+ORMQRF_LAUNCHER_SCRATCH(float, cusolverDnSormqr_bufferSize)
+ORMQRF_LAUNCHER_SCRATCH(double, cusolverDnDormqr_bufferSize)
+
+#undef ORMQRF_LAUNCHER_SCRATCH
+
+template <typename Func>
+inline void ormtr_scratchpad_size(Func func, sycl::queue &queue, oneapi::mkl::side side,
+                                  oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
+                                  std::int64_t m, std::int64_t n, std::int64_t lda,
+                                  std::int64_t ldc, int *scratch_size) {
+    queue.submit([&](cl::sycl::handler &cgh) {
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_side_mode(side),
+                                get_cublas_fill_mode(uplo), get_cublas_operation(trans), m, n,
+                                nullptr, lda, nullptr, nullptr, ldc, scratch_size);
+        });
+    });
 }
-template <>
-std::int64_t ormtr_scratchpad_size<float>(sycl::queue &queue, oneapi::mkl::side side,
-                                          oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
-                                          std::int64_t m, std::int64_t n, std::int64_t lda,
-                                          std::int64_t ldc) {
-    throw unimplemented("lapack", "ormtr_scratchpad_size");
-}
-template <>
-std::int64_t ormtr_scratchpad_size<double>(sycl::queue &queue, oneapi::mkl::side side,
-                                           oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
-                                           std::int64_t m, std::int64_t n, std::int64_t lda,
-                                           std::int64_t ldc) {
-    throw unimplemented("lapack", "ormtr_scratchpad_size");
-}
+
+#define ORMTR_LAUNCHER_SCRATCH(TYPE, CUSOLVER_ROUTINE)                                             \
+    template <>                                                                                    \
+    std::int64_t ormtr_scratchpad_size<TYPE>(sycl::queue & queue, oneapi::mkl::side side,          \
+                                             oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans, \
+                                             std::int64_t m, std::int64_t n, std::int64_t lda,     \
+                                             std::int64_t ldc) {                                   \
+        int scratch_size;                                                                          \
+        ormtr_scratchpad_size(CUSOLVER_ROUTINE, queue, side, uplo, trans, m, n, lda, ldc,          \
+                              &scratch_size);                                                      \
+        return scratch_size;                                                                       \
+    }
+
+ORMTR_LAUNCHER_SCRATCH(float, cusolverDnSormtr_bufferSize)
+ORMTR_LAUNCHER_SCRATCH(double, cusolverDnDormtr_bufferSize)
+
+#undef ORMTR_LAUNCHER_SCRATCH
 
 template <typename Func>
 inline void potrf_scratchpad_size(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo,
@@ -1682,38 +2240,64 @@ std::int64_t potri_scratchpad_size<std::complex<double>>(sycl::queue &queue, one
                                                          std::int64_t n, std::int64_t lda) {
     throw unimplemented("lapack", "potri_scratchpad_size");
 }
-template <>
-std::int64_t sytrf_scratchpad_size<float>(sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                          std::int64_t n, std::int64_t lda) {
-    throw unimplemented("lapack", "sytrf_scratchpad_size");
+
+template <typename Func>
+inline void sytrf_scratchpad_size(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                  std::int64_t n, std::int64_t lda, int *scratch_size) {
+    queue.submit([&](cl::sycl::handler &cgh) {
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, n, nullptr, lda, scratch_size);
+        });
+    });
 }
-template <>
-std::int64_t sytrf_scratchpad_size<double>(sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                           std::int64_t n, std::int64_t lda) {
-    throw unimplemented("lapack", "sytrf_scratchpad_size");
+
+#define SYTRF_LAUNCHER_SCRATCH(TYPE, CUSOLVER_ROUTINE)                                    \
+    template <>                                                                           \
+    std::int64_t sytrf_scratchpad_size<TYPE>(sycl::queue & queue, oneapi::mkl::uplo uplo, \
+                                             std::int64_t n, std::int64_t lda) {          \
+        int scratch_size;                                                                 \
+        sytrf_scratchpad_size(CUSOLVER_ROUTINE, queue, uplo, n, lda, &scratch_size);      \
+        return scratch_size;                                                              \
+    }
+
+SYTRF_LAUNCHER_SCRATCH(float, cusolverDnSsytrf_bufferSize)
+SYTRF_LAUNCHER_SCRATCH(double, cusolverDnDsytrf_bufferSize)
+SYTRF_LAUNCHER_SCRATCH(std::complex<float>, cusolverDnCsytrf_bufferSize)
+SYTRF_LAUNCHER_SCRATCH(std::complex<double>, cusolverDnZsytrf_bufferSize)
+
+#undef SYTRF_LAUNCHER_SCRATCH
+
+template <typename Func>
+inline void syevd_scratchpad_size(Func func, sycl::queue &queue, oneapi::mkl::job jobz,
+                                  oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t lda,
+                                  int *scratch_size) {
+    queue.submit([&](cl::sycl::handler &cgh) {
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cusolver_job(jobz),
+                                get_cublas_fill_mode(uplo), n, nullptr, lda, nullptr, scratch_size);
+        });
+    });
 }
-template <>
-std::int64_t sytrf_scratchpad_size<std::complex<float>>(sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                        std::int64_t n, std::int64_t lda) {
-    throw unimplemented("lapack", "sytrf_scratchpad_size");
-}
-template <>
-std::int64_t sytrf_scratchpad_size<std::complex<double>>(sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                         std::int64_t n, std::int64_t lda) {
-    throw unimplemented("lapack", "sytrf_scratchpad_size");
-}
-template <>
-std::int64_t syevd_scratchpad_size<float>(sycl::queue &queue, oneapi::mkl::job jobz,
-                                          oneapi::mkl::uplo uplo, std::int64_t n,
-                                          std::int64_t lda) {
-    throw unimplemented("lapack", "syevd_scratchpad_size");
-}
-template <>
-std::int64_t syevd_scratchpad_size<double>(sycl::queue &queue, oneapi::mkl::job jobz,
-                                           oneapi::mkl::uplo uplo, std::int64_t n,
-                                           std::int64_t lda) {
-    throw unimplemented("lapack", "syevd_scratchpad_size");
-}
+
+#define SYEVD_LAUNCHER_SCRATCH(TYPE, CUSOLVER_ROUTINE)                                     \
+    template <>                                                                            \
+    std::int64_t syevd_scratchpad_size<TYPE>(sycl::queue & queue, oneapi::mkl::job jobz,   \
+                                             oneapi::mkl::uplo uplo, std::int64_t n,       \
+                                             std::int64_t lda) {                           \
+        int scratch_size;                                                                  \
+        syevd_scratchpad_size(CUSOLVER_ROUTINE, queue, jobz, uplo, n, lda, &scratch_size); \
+        return scratch_size;                                                               \
+    }
+
+SYEVD_LAUNCHER_SCRATCH(float, cusolverDnSsyevd_bufferSize)
+SYEVD_LAUNCHER_SCRATCH(double, cusolverDnDsyevd_bufferSize)
+
+#undef SYEVD_LAUNCHER_SCRATCH
+
 template <>
 std::int64_t sygvd_scratchpad_size<float>(sycl::queue &queue, std::int64_t itype,
                                           oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
@@ -1726,16 +2310,34 @@ std::int64_t sygvd_scratchpad_size<double>(sycl::queue &queue, std::int64_t ityp
                                            std::int64_t n, std::int64_t lda, std::int64_t ldb) {
     throw unimplemented("lapack", "sygvd_scratchpad_size");
 }
-template <>
-std::int64_t sytrd_scratchpad_size<float>(sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                          std::int64_t n, std::int64_t lda) {
-    throw unimplemented("lapack", "sytrd_scratchpad_size");
+
+template <typename Func>
+inline void sytrd_scratchpad_size(Func func, sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                  std::int64_t n, std::int64_t lda, int *scratch_size) {
+    queue.submit([&](cl::sycl::handler &cgh) {
+        onemkl_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler &sc) {
+            auto handle = sc.get_handle(queue);
+            cusolverStatus_t err;
+            CUSOLVER_ERROR_FUNC(func, err, handle, get_cublas_fill_mode(uplo), n, nullptr, lda,
+                                nullptr, nullptr, nullptr, scratch_size);
+        });
+    });
 }
-template <>
-std::int64_t sytrd_scratchpad_size<double>(sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                           std::int64_t n, std::int64_t lda) {
-    throw unimplemented("lapack", "sytrd_scratchpad_size");
-}
+
+#define SYTRD_LAUNCHER_SCRATCH(TYPE, CUSOLVER_ROUTINE)                                    \
+    template <>                                                                           \
+    std::int64_t sytrd_scratchpad_size<TYPE>(sycl::queue & queue, oneapi::mkl::uplo uplo, \
+                                             std::int64_t n, std::int64_t lda) {          \
+        int scratch_size;                                                                 \
+        sytrd_scratchpad_size(CUSOLVER_ROUTINE, queue, uplo, n, lda, &scratch_size);      \
+        return scratch_size;                                                              \
+    }
+
+SYTRD_LAUNCHER_SCRATCH(float, cusolverDnSsytrd_bufferSize)
+SYTRD_LAUNCHER_SCRATCH(double, cusolverDnDsytrd_bufferSize)
+
+#undef SYTRD_LAUNCHER_SCRATCH
+
 template <>
 std::int64_t trtrs_scratchpad_size<float>(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                           oneapi::mkl::transpose trans, oneapi::mkl::diag diag,


### PR DESCRIPTION
+ functions
   - orgbr
   - orgqr
   - orgtr
   - ormtr
   - ormqr
   - syevd
   - sytrd
   - sytrf

+ helpers
   - get_cusolver_job
   - get_cublas_generate

# Description

Please include a summary of the change. Please also include relevant
motivation and context. See
[contribution guidelines](https://github.com/oneapi-src/oneMKL/blob/master/CONTRIBUTING.md)
for more details. If the change fixes an issue not documented in the project's
Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (GitHub issue)

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [ ] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
